### PR TITLE
Fix discrepancy in front matter example

### DIFF
--- a/content/blog/2019/2019-05-03-meta-descriptions-in-hugo-templates.md
+++ b/content/blog/2019/2019-05-03-meta-descriptions-in-hugo-templates.md
@@ -78,7 +78,7 @@ When you've decided what the description should be, there are different options 
    layout: post
    title: "My awesome blog post"
    date: 2015-12-15 00:00:01
-   description: "An insightful description for this page that Google will like"
+   summary: "An insightful description for this page that Google will like"
    ---
    ```
 


### PR DESCRIPTION
For this post: https://www.clairecodes.com/blog/2019-05-03-meta-descriptions-in-hugo-templates/

The front matter said "description: ..." but the reference to it said `.Params.summary`. This PR changes description -> summary in the front matter.